### PR TITLE
Websocket channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "eslint-plugin-import": "^2.0.1",
     "jsdoc": "^3.4.2",
     "mocha": "^3.1.2",
-    "nyc": "^8.3.1"
+    "nyc": "^8.3.1",
+    "ws": "^1.1.1"
   },
   "babel": {
     "presets": [

--- a/src/kernels.js
+++ b/src/kernels.js
@@ -188,10 +188,8 @@ export function restart(serverConfig, id) {
 }
 
 export function formWebSocketURL(serverConfig, id) {
-  const url = new URL(`${serverConfig.endpoint}/api/kernels/${id}/channels`);
-  // Change protocol to ws on http and wss on https
-  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-  return url.toString();
+  const url = `${serverConfig.endpoint}/api/kernels/${id}/channels`;
+  return url.replace(/^http(s)?/, 'ws$1');
 }
 
 export function connect(serverConfig, id) {

--- a/src/kernels.js
+++ b/src/kernels.js
@@ -1,6 +1,8 @@
 import { ajax } from 'rxjs/observable/dom/ajax';
 import 'rxjs/add/operator/map';
 
+import { webSocket } from 'rxjs/observable/dom/webSocket';
+
 /**
  * Creates the AJAX settings for a call to the kernels API.
  *
@@ -183,4 +185,15 @@ export function interrupt(serverConfig, id) {
  */
 export function restart(serverConfig, id) {
   return ajax(createSettingsForRestart(serverConfig, id));
+}
+
+export function formWebSocketURL(serverConfig, id) {
+  const url = new URL(`${serverConfig.endpoint}/api/kernels/${id}/channels`);
+  // Change protocol to ws on http and wss on https
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+export function connect(serverConfig, id) {
+  return webSocket(formWebSocketURL(serverConfig, id));
 }

--- a/test/kernel-spec.js
+++ b/test/kernel-spec.js
@@ -2,6 +2,9 @@ import { expect } from 'chai';
 
 import * as kernels from '../src/kernels';
 
+// For the test using a websocket
+global.WebSocket = require('ws');
+
 const serverConfig = {
   endpoint: 'http://localhost:8888',
   crossDomain: true,
@@ -156,13 +159,27 @@ describe('kernels', () => {
 
   describe('formWebSocketURL', () => {
     it('creates websocket URLs that match the originating scheme', () => {
-      const serverConfig = {
+      const config = {
         endpoint: 'https://tmp58.tmpnb.org/user/TOTefPUbkgOu',
       };
-      const wsURL = kernels.formWebSocketURL(serverConfig, '0000-1111');
+      const wsURL = kernels.formWebSocketURL(config, '0000-1111');
       expect(wsURL).to.equal(
         'wss://tmp58.tmpnb.org/user/TOTefPUbkgOu/api/kernels/0000-1111/channels'
       );
+
+      config.endpoint = 'http://127.0.0.1:8888';
+
+      const wsURL2 = kernels.formWebSocketURL(config, '4444-2222');
+      expect(wsURL2).to.equal(
+        'ws://127.0.0.1:8888/api/kernels/4444-2222/channels'
+      );
+    });
+  });
+
+  describe('connect', () => {
+    it('returns a WebSocketSubject attached to the kernel', () => {
+      const subject = kernels.connect(serverConfig, '777');
+      expect(subject.url).to.equal('ws://localhost:8888/api/kernels/777/channels');
     });
   });
 });

--- a/test/kernel-spec.js
+++ b/test/kernel-spec.js
@@ -153,4 +153,16 @@ describe('kernels', () => {
       expect(request.method).to.equal('POST');
     });
   });
+
+  describe('formWebSocketURL', () => {
+    it('creates websocket URLs that match the originating scheme', () => {
+      const serverConfig = {
+        endpoint: 'https://tmp58.tmpnb.org/user/TOTefPUbkgOu',
+      };
+      const wsURL = kernels.formWebSocketURL(serverConfig, '0000-1111');
+      expect(wsURL).to.equal(
+        'wss://tmp58.tmpnb.org/user/TOTefPUbkgOu/api/kernels/0000-1111/channels'
+      );
+    });
+  });
 });


### PR DESCRIPTION
This completes our roundup of the kernels API. Usage:

```js
const socketSubject = jupyter.kernels.connect(serverConfig, kernelID);

socketSubject.subscribe(message => ...);

socketSubject.send(JSON.stringify(message)); // message is a Jupyter message
```

Careful notes though, which bears caution of a changing API to make things easier:

* Jupyter WebSockets are now multiplexed, which has an effect on the messages - they include a `channel` key for `iopub`, `shell`, or `stdin`.
* Jupyter messages on the websockets appear to extract and include a few keys out of the header, namely `msg_type` and `msg_id` (they do also appear in the header). It's not clear to me if we have to set these at a higher level for the server.
* The WebSocketSubject appears to automatically deserialize messages from the server on the websocket into JavaScript Objects - however (and wisely so as I'll point out in a second), you must `JSON.stringify` messages you send to the backend
* Binary buffers are not handled here

In order to make this conform to the same interface we use with enchannel-zmq, it will require some extra adaptation. All that being said, this gets us started!

/cc @minrk for awareness