### PR TITLE
feat(version): observable for jupyter api version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,14 @@
+import { ajax } from 'rxjs/observable/dom/ajax';
+
 import * as kernels from './kernels';
 import * as kernelspecs from './kernelspecs';
 
-export { kernels, kernelspecs };
+function apiVersion(serverConfig) {
+  return ajax({
+    url: `${serverConfig.endpoint}/api`,
+    crossDomain: serverConfig.crossDomain,
+    responseType: 'json',
+  });
+}
+
+export { apiVersion, kernels, kernelspecs };

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -2,10 +2,22 @@ import { expect } from 'chai';
 
 import * as jupyter from '../src';
 
-// Mostly a dummy "have we exported all the things" test
 describe('rx-jupyter', () => {
+  // Mostly a dummy "have we exported all the things" test
   it('exports kernels and kernelspecs', () => {
     expect(jupyter.kernels).to.not.be.null; // eslint-disable-line no-unused-expressions
     expect(jupyter.kernelspecs).to.not.be.null; // eslint-disable-line no-unused-expressions
+  });
+
+  describe('apiVersion', () => {
+    it('creates an AjaxObservable for getting the notebook server version', () => {
+      const apiVersion$ = jupyter.apiVersion({
+        endpoint: 'https://somewhere.com',
+        crossDomain: true,
+      });
+      const request = apiVersion$.request;
+      expect(request.url).to.equal('https://somewhere.com/api');
+      expect(request.method).to.equal('GET');
+    });
   });
 });


### PR DESCRIPTION
Figured it would be nice to find out the API version of the server. Might even have to use this to change how we touch the API.