### PR TITLE
feat(kernelspecs): get a single kernelspec

### DIFF
--- a/src/kernelspecs.js
+++ b/src/kernelspecs.js
@@ -17,6 +17,15 @@ export function createSettingsForList(serverConfig) {
   };
 }
 
+export function createSettingsForGet(serverConfig, name) {
+  const url = `${serverConfig.endpoint}/api/kernelspecs/${name}`;
+  return {
+    url,
+    crossDomain: serverConfig.crossDomain,
+    responseType: 'json',
+  };
+}
+
 /**
  * Creates an AjaxObservable for listing avaialble kernelspecs.
  *
@@ -26,4 +35,8 @@ export function createSettingsForList(serverConfig) {
  */
 export function list(serverConfig) {
   return ajax(createSettingsForList(serverConfig));
+}
+
+export function get(serverConfig, name) {
+  return ajax(createSettingsForGet(serverConfig, name));
 }

--- a/test/kernelspecs-spec.js
+++ b/test/kernelspecs-spec.js
@@ -21,10 +21,19 @@ describe('kernelspecs', () => {
   });
 
   describe('list', () => {
-    it('creates an AjaxObservable configured for listing', () => {
+    it('creates an AjaxObservable for listing the kernelspecs', () => {
       const kernelSpec$ = kernelspecs.list(serverConfig);
       const request = kernelSpec$.request;
       expect(request.url).to.equal('http://localhost:8888/api/kernelspecs');
+      expect(request.method).to.equal('GET');
+    });
+  });
+
+  describe('get', () => {
+    it('creates an AjaxObservable for getting a kernelspec', () => {
+      const kernelSpec$ = kernelspecs.get(serverConfig, 'python3000');
+      const request = kernelSpec$.request;
+      expect(request.url).to.equal('http://localhost:8888/api/kernelspecs/python3000');
       expect(request.method).to.equal('GET');
     });
   });


### PR DESCRIPTION
This finishes off the rest of the kernelspec API. I was referring to the doc to see what else we missed.