### PR TITLE
Ajax settings revamp

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -5,6 +5,8 @@ export function normalizeBaseURL(url) {
 export function createAJAXSettings(serverConfig, uri = '/', opts = {}) {
   const baseURL = normalizeBaseURL(serverConfig.endpoint || serverConfig.url);
   const url = `${baseURL}${uri}`;
+  // Merge in our typical settings for responseType, allow setting additional options
+  // like the method
   const settings = Object.assign({
     url,
     responseType: 'json',

--- a/src/base.js
+++ b/src/base.js
@@ -2,11 +2,14 @@ export function normalizeBaseURL(url) {
   return url.replace(/\/+$/, '');
 }
 
-export function createAJAXSettings(serverConfig, uri = '/') {
+export function createAJAXSettings(serverConfig, uri = '/', opts = {}) {
   const baseURL = normalizeBaseURL(serverConfig.endpoint || serverConfig.url);
   const url = `${baseURL}${uri}`;
-  return Object.assign({
+  const settings = Object.assign({
     url,
     responseType: 'json',
-  }, serverConfig);
+  }, serverConfig, opts);
+
+  delete settings.endpoint;
+  return settings;
 }

--- a/src/base.js
+++ b/src/base.js
@@ -1,0 +1,12 @@
+export function normalizeBaseURL(url) {
+  return url.replace(/\/+$/, '');
+}
+
+export function createAJAXSettings(serverConfig, uri = '/') {
+  const baseURL = normalizeBaseURL(serverConfig.endpoint || serverConfig.url);
+  const url = `${baseURL}${uri}`;
+  return Object.assign({
+    url,
+    responseType: 'json',
+  }, serverConfig);
+}

--- a/src/contents.js
+++ b/src/contents.js
@@ -2,11 +2,19 @@ import { ajax } from 'rxjs/observable/dom/ajax';
 
 import { join as pathJoin } from 'path';
 
+import {
+  createAJAXSettings,
+} from './base';
+
 const querystring = require('querystring');
 
 export function formURL(serverConfig, path) {
   const contentPath = pathJoin('/api/contents/', path);
   return `${serverConfig.endpoint}${contentPath}`;
+}
+
+export function formURI(path) {
+  return pathJoin('/api/contents/', path);
 }
 
 /**
@@ -25,18 +33,13 @@ export function formURL(serverConfig, path) {
  */
 export function createSettingsForGet(serverConfig, path, params) {
   // TODO: Does path need to be normalized?
-  let url = formURL(serverConfig, path);
+  let uri = formURI(path);
   const query = querystring.stringify(params);
-
   if (query.length > 0) {
-    url = `${url}?${query}`;
+    uri = `${uri}?${query}`;
   }
 
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, uri);
 }
 
 /**
@@ -66,17 +69,17 @@ export function createSettingsForGet(serverConfig, path, params) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForCreate(serverConfig, path, model) {
-  const url = formURL(serverConfig, path);
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
+  const uri = formURI(path);
+
+  const opts = {
     headers: {
       'Content-Type': 'application/json',
     },
     method: 'POST',
     body: model,
   };
+
+  return createAJAXSettings(serverConfig, uri, opts);
 }
 
 /**
@@ -88,13 +91,13 @@ export function createSettingsForCreate(serverConfig, path, model) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForRemove(serverConfig, path) {
-  const url = formURL(serverConfig, path);
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
+  const uri = formURI(path);
+
+  const opts = {
     method: 'DELETE',
   };
+
+  return createAJAXSettings(serverConfig, uri, opts);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,13 @@ import * as kernelspecs from './kernelspecs';
 import * as sessions from './sessions';
 import * as contents from './contents';
 
+import {
+  createAJAXSettings,
+} from './base';
+
 function apiVersion(serverConfig) {
-  return ajax({
-    url: `${serverConfig.endpoint}/api`,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  });
+  const req = createAJAXSettings(serverConfig, '/api');
+  return ajax(req);
 }
 
 export { apiVersion, kernels, kernelspecs, sessions, contents };

--- a/src/kernels.js
+++ b/src/kernels.js
@@ -2,6 +2,10 @@ import { ajax } from 'rxjs/observable/dom/ajax';
 
 import { webSocket } from 'rxjs/observable/dom/webSocket';
 
+import {
+  createAJAXSettings,
+} from './base';
+
 /**
  * Creates the AJAX settings for a call to the kernels API.
  *
@@ -10,12 +14,7 @@ import { webSocket } from 'rxjs/observable/dom/webSocket';
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForList(serverConfig) {
-  const url = `${serverConfig.endpoint}/api/kernels`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, '/api/kernels');
 }
 
 /**
@@ -26,12 +25,7 @@ export function createSettingsForList(serverConfig) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForGet(serverConfig, id) {
-  const url = `${serverConfig.endpoint}/api/kernels/${id}`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, `/api/kernels/${id}`);
 }
 
 /**
@@ -44,11 +38,7 @@ export function createSettingsForGet(serverConfig, id) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForStart(serverConfig, name, path) {
-  const url = `${serverConfig.endpoint}/api/kernels`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
+  return createAJAXSettings(serverConfig, '/api/kernels', {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -57,7 +47,7 @@ export function createSettingsForStart(serverConfig, name, path) {
       path,
       kernel_name: name,
     },
-  };
+  });
 }
 
 /**
@@ -69,13 +59,7 @@ export function createSettingsForStart(serverConfig, name, path) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForKill(serverConfig, id) {
-  const url = `${serverConfig.endpoint}/api/kernels/${id}`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-    method: 'DELETE',
-  };
+  return createAJAXSettings(serverConfig, `/api/kernels/${id}`, { method: 'DELETE' });
 }
 
 /**
@@ -87,13 +71,7 @@ export function createSettingsForKill(serverConfig, id) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForInterrupt(serverConfig, id) {
-  const url = `${serverConfig.endpoint}/api/kernels/${id}/interrupt`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-    method: 'POST',
-  };
+  return createAJAXSettings(serverConfig, `/api/kernels/${id}/interrupt`, { method: 'POST' });
 }
 
 /**
@@ -105,13 +83,7 @@ export function createSettingsForInterrupt(serverConfig, id) {
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForRestart(serverConfig, id) {
-  const url = `${serverConfig.endpoint}/api/kernels/${id}/restart`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-    method: 'POST',
-  };
+  return createAJAXSettings(serverConfig, `/api/kernels/${id}/restart`, { method: 'POST' });
 }
 
 /**

--- a/src/kernelspecs.js
+++ b/src/kernelspecs.js
@@ -1,5 +1,9 @@
 import { ajax } from 'rxjs/observable/dom/ajax';
 
+import {
+  createAJAXSettings,
+} from './base';
+
 /**
  * Creates the AJAX settings for a call to the kernelspecs API.
  *
@@ -8,21 +12,11 @@ import { ajax } from 'rxjs/observable/dom/ajax';
  * @return  {Object}  The settings to be passed to the AJAX request
  */
 export function createSettingsForList(serverConfig) {
-  const url = `${serverConfig.endpoint}/api/kernelspecs`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, '/api/kernelspecs');
 }
 
 export function createSettingsForGet(serverConfig, name) {
-  const url = `${serverConfig.endpoint}/api/kernelspecs/${name}`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, `/api/kernelspecs/${name}`);
 }
 
 /**

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -1,5 +1,9 @@
 import { ajax } from 'rxjs/observable/dom/ajax';
 
+import {
+  createAJAXSettings,
+} from './base';
+
 /**
  * Creates the AJAX settings for a call to the sessions API.
  *
@@ -8,12 +12,7 @@ import { ajax } from 'rxjs/observable/dom/ajax';
  * @return {Object} settings - The settings to be passed to the AJAX request
  */
 export function createSettingsForList(serverConfig) {
-  const url = `${serverConfig.endpoint}/api/sessions`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, '/api/sessions');
 }
 
 /**
@@ -26,12 +25,7 @@ export function createSettingsForList(serverConfig) {
  * @return {Object} - The settings to be passed to the AJAX request
  */
 export function createSettingsForGet(serverConfig, sessionID) {
-  const url = `${serverConfig.endpoint}/api/sessions/${sessionID}`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-  };
+  return createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`);
 }
 
 /**
@@ -44,13 +38,7 @@ export function createSettingsForGet(serverConfig, sessionID) {
  * @return {Object} - The settings to be passed to the AJAX request
  */
 export function createSettingsForDestroy(serverConfig, sessionID) {
-  const url = `${serverConfig.endpoint}/api/sessions/${sessionID}`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
-    method: 'DELETE',
-  };
+  return createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, { method: 'DELETE' });
 }
 
 /**
@@ -65,17 +53,13 @@ export function createSettingsForDestroy(serverConfig, sessionID) {
  * @return  {Object} - The settings to be passed to the AJAX request
  */
 export function createSettingsForUpdate(serverConfig, sessionID, body) {
-  const url = `${serverConfig.endpoint}/api/sessions/${sessionID}`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
+  return createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
+    method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },
-    method: 'PATCH',
     body,
-  };
+  });
 }
 
 /**
@@ -88,17 +72,13 @@ export function createSettingsForUpdate(serverConfig, sessionID, body) {
  * @return {Object} - The settings to be passed to the AJAX request
  */
 export function createSettingsForCreate(serverConfig, body) {
-  const url = `${serverConfig.endpoint}/api/sessions`;
-  return {
-    url,
-    crossDomain: serverConfig.crossDomain,
-    responseType: 'json',
+  return createAJAXSettings(serverConfig, '/api/sessions', {
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    method: 'POST',
     body,
-  };
+  });
 }
 
 /**


### PR DESCRIPTION
Trimmed down our boilerplate a little bit and made it so we can pass `withCredentials: true` as part of our config so we can pass cookies on when dealing with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).