### PR TITLE
chore(contents): delete unused function

### DIFF
--- a/src/contents.js
+++ b/src/contents.js
@@ -8,11 +8,6 @@ import {
 
 const querystring = require('querystring');
 
-export function formURL(serverConfig, path) {
-  const contentPath = pathJoin('/api/contents/', path);
-  return `${serverConfig.endpoint}${contentPath}`;
-}
-
 export function formURI(path) {
   return pathJoin('/api/contents/', path);
 }


### PR DESCRIPTION
_Now_ I see how coverage went down in the ajax settings refactor PR I made. I simplified things enough to not need this function anymore, which meant that it was sitting there without being used and therefore not covered.

Let's take it out.

I also realize now that we should definitely only export the names we want from each module `kernels`, `kernelspecs`, etc. so that we're not leaking out the createSettings* functions to our primary namespace.